### PR TITLE
Feature - use behaviours

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@ extends:
 
 rules:
   no-const-assign: error
+  no-underscore-dangle: off
   object-curly-spacing:
     - error
     - always

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The minimum amount of configuration for a wizard step is the `next` property to 
 * `fields` - specifies which of the fields from the field definition list are applied to this step. Form inputs which are not named on this list will not be processed. Default: `[]`
 * `template` - Specifies the template to render for GET requests to this step. Defaults to the route (without trailing slash)
 * `backLink` - Specifies the location of the step previous to this one. If not specified then an algorithm is applied which checks the previously visited steps which have the current step set as `next`.
-* `behaviours` - A single behaviour, or an array of behaviours to be mixed into the base controller to extend functionality.
+* `behaviours` - A single behaviour, or an array of behaviours to be mixed into the base controller to extend functionality. If an array of behaviours is given, they are applied left-to-right, so calling super in the right-most behaviour will point to the previous behaviour in the array.
 * `forks` - Specifies a list of forks that can be taken depending on a particular field value or conditional function - See  [handling forking journeys](https://github.com/UKHomeOffice/passports-form-controller#handles-journey-forking) in hof-form-controller.
 
 ### Additional field options
@@ -91,11 +91,13 @@ Creating a behaviour:
 // behaviour-one.js
 
 module.exports = SuperClass => class extends SuperClass {
-  constructor() {
-    super();
-    this.use((req, res, next) => {
-      console.log(req.method, req.url);
-      next();
+  getValues(req, res, callback) {
+    super.getValues(req, res, (err, values) => {
+      if (err) {
+        return callback(err);
+      }
+      const errorValues = req.sessionModel.get('errorValues') || {};
+      return callback(null, Object.assign({}, values, errorValues))
     });
   }
 }

--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -14,8 +14,8 @@ const createController = (SuperClass, behaviours) => {
    *
    * class Controller extends mix(SuperClass).with(...behaviours) {}
    */
-  let _mix;
-  return class extends (_mix = mix(SuperClass)).with.apply(_mix, behaviours) {};
+  const _mix = mix(SuperClass);
+  return class extends _mix.with.apply(_mix, behaviours) {};
 };
 
 const Wizard = (steps, fields, settings) => {

--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -2,9 +2,21 @@
 
 const express = require('express');
 const _ = require('lodash');
-const FormController = require('hof-controllers').base;
+const FormController = require('hof-form-controller');
+const mix = require('mixwith').mix;
 
 let count = 0;
+
+const createController = (SuperClass, behaviours) => {
+  /*
+   * This class declaration could be better written using
+   * array spread syntax, supported in node >= 5.11.0:
+   *
+   * class Controller extends mix(SuperClass).with(...behaviours) {}
+   */
+  let _mix;
+  return class extends (_mix = mix(SuperClass)).with.apply(_mix, behaviours) {};
+};
 
 const Wizard = (steps, fields, settings) => {
   settings = Object.assign({
@@ -45,9 +57,22 @@ const Wizard = (steps, fields, settings) => {
       options.template = settings.templatePath + '/' + options.template;
     }
 
-    const Controller = options.controller || settings.controller;
+    options.i18n = settings.i18n;
 
-    const controller = new Controller(options);
+    const SuperClass = options.controller || settings.controller;
+
+    if (options.controller) {
+      // eslint-disable-next-line no-console
+      console.warn('hof-form-wizard: Passing a custom step controller is deprecated');
+      // eslint-disable-next-line no-console, max-len
+      console.warn('hof-form-wizard: Instead give one or more behaviours which will be mixed in to the base controller');
+    }
+
+    const behaviours = options.behaviours ? _.castArray(options.behaviours) : [];
+
+    const controller = new (behaviours.length ?
+      createController(SuperClass, behaviours) :
+      SuperClass)(options);
 
     controller.use([
       require('./middleware/check-session')(route, controller, steps, first),

--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -2,6 +2,7 @@
 
 const express = require('express');
 const _ = require('lodash');
+const deprecate = require('deprecate');
 const FormController = require('hof-form-controller');
 const mix = require('mixwith').mix;
 
@@ -62,10 +63,10 @@ const Wizard = (steps, fields, settings) => {
     const SuperClass = options.controller || settings.controller;
 
     if (options.controller) {
-      // eslint-disable-next-line no-console
-      console.warn('hof-form-wizard: Passing a custom step controller is deprecated');
-      // eslint-disable-next-line no-console, max-len
-      console.warn('hof-form-wizard: Instead give one or more behaviours which will be mixed in to the base controller');
+      deprecate(
+        'hof-form-wizard: Passing a custom step controller is deprecated',
+        'Instead give one or more behaviours which will be mixed in to the base controller'
+      );
     }
 
     const behaviours = options.behaviours ? _.castArray(options.behaviours) : [];

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "csrf": "^3.0.2",
     "debug": "^2.1.2",
+    "deprecate": "^1.0.0",
     "express": "^4.12.2",
     "hof-form-controller": "^3.0.1",
     "hof-model": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "eslint-config-homeoffice": "^2.0.0",
     "istanbul": "^0.4.3",
     "mocha": "^3.1.2",
-    "proxyquire": "^1.7.11",
     "reqres": "^1.2.0",
     "sinon": "^1.17.6",
     "sinon-chai": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -28,17 +28,19 @@
     "csrf": "^3.0.2",
     "debug": "^2.1.2",
     "express": "^4.12.2",
+    "hof-form-controller": "^3.0.1",
     "hof-model": "^2.0.0",
-    "hof-controllers": "^6.0.0",
     "hogan.js": "^3.0.2",
     "i18n-lookup": "^0.1.0",
-    "lodash": "^4.17.2"
+    "lodash": "^4.17.2",
+    "mixwith": "^0.1.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint-config-homeoffice": "^2.0.0",
     "istanbul": "^0.4.3",
     "mocha": "^3.1.2",
+    "proxyquire": "^1.7.11",
     "reqres": "^1.2.0",
     "sinon": "^1.17.6",
     "sinon-chai": "^2.8.0",

--- a/test/helpers/behaviour.js
+++ b/test/helpers/behaviour.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = SuperClass => class extends SuperClass {};

--- a/test/middleware/spec.check-progress.js
+++ b/test/middleware/spec.check-progress.js
@@ -2,7 +2,7 @@
 
 const checkProgress = require('../../lib/middleware/check-progress');
 const Model = require('../../lib/model');
-const Controller = require('hof-controllers').base;
+const Controller = require('hof-form-controller');
 const helpers = require('../../lib/util/helpers');
 
 const request = require('../helpers/request');

--- a/test/spec.wizard.js
+++ b/test/spec.wizard.js
@@ -102,21 +102,10 @@ describe('Form Wizard', () => {
   describe('behaviours', () => {
     beforeEach(() => {
       sinon.spy(obj, 'Behaviour');
-      sinon.stub(console, 'warn');
     });
 
     afterEach(() => {
       obj.Behaviour.restore();
-      console.warn.restore();
-    });
-
-    it('logs a deprecated warning if a custom controller is given', () => {
-      Wizard({
-        '/': {
-          controller: StubController()
-        }
-      }, {}, {});
-      console.warn.should.have.been.calledTwice;
     });
 
     it('accepts a single behaviour', () => {


### PR DESCRIPTION
This PR removes the dependency on hof-controllers and instead installs hof-form-controller ^3.0.1 which already has hooks and session IO mixed in. Also installed mixwith.js so steps can now provide one or more custom "behaviours" in place of a singular custom controller. Custom controllers are still supported but a deprication warning is now shown if a custom controller is used.