### PR TITLE
Move complexity of controller construction out into function

### DIFF
--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -8,7 +8,11 @@ const mix = require('mixwith').mix;
 
 let count = 0;
 
-const createController = (SuperClass, behaviours) => {
+const getController = (SuperClass, behaviours) => {
+  behaviours = behaviours ? _.castArray(behaviours) : [];
+  if (!behaviours.length) {
+    return SuperClass;
+  }
   /*
    * This class declaration could be better written using
    * array spread syntax, supported in node >= 5.11.0:
@@ -60,8 +64,6 @@ const Wizard = (steps, fields, settings) => {
 
     options.i18n = settings.i18n;
 
-    const SuperClass = options.controller || settings.controller;
-
     if (options.controller) {
       deprecate(
         'hof-form-wizard: Passing a custom step controller is deprecated',
@@ -69,11 +71,9 @@ const Wizard = (steps, fields, settings) => {
       );
     }
 
-    const behaviours = options.behaviours ? _.castArray(options.behaviours) : [];
-
-    const controller = new (behaviours.length ?
-      createController(SuperClass, behaviours) :
-      SuperClass)(options);
+    const SuperClass = options.controller || settings.controller;
+    const Controller = getController(SuperClass, options.behaviours);
+    const controller = new Controller(options);
 
     controller.use([
       require('./middleware/check-session')(route, controller, steps, first),


### PR DESCRIPTION
The core function is already quite complex, and having nested function calls inside a multiline ternary operator makes it diffcult to easily parse.

Instead move the checks/coercing of behaviours out into the controller function, so the core function code is simple steps.