### PR TITLE
Complete behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The minimum amount of configuration for a wizard step is the `next` property to 
 * `backLink` - Specifies the location of the step previous to this one. If not specified then an algorithm is applied which checks the previously visited steps which have the current step set as `next`.
 * `behaviours` - A single behaviour, or an array of behaviours to be mixed into the base controller to extend functionality. If an array of behaviours is given, they are applied left-to-right, so calling super in the right-most behaviour will point to the previous behaviour in the array.
 * `forks` - Specifies a list of forks that can be taken depending on a particular field value or conditional function - See  [handling forking journeys](https://github.com/UKHomeOffice/passports-form-controller#handles-journey-forking) in hof-form-controller.
+* `allowPostComplete` - If set to true allows a step to be accessed after the application has been completed. If not set then accessing this step will reset the session.
 
 ### Additional field options
 
@@ -116,3 +117,30 @@ app.use(Wizard({
   }
 }, {}, {}));
 ```
+
+### Predefined behaviours
+
+Some behaviours are built-in to the Wizard, and can be declared by passing a string as a behaviour.
+
+These are:
+
+* `complete` - if set to a step then this step will mark the application as complete. The user will then have their session reset if they attempt to access any step of the form. Steps which follow a complete-ing step should have their `allowPostComplete` option et to true.
+
+
+```js
+//index.js
+const app = require('express')();
+const Wizard = require('hof-form-wizard')
+
+app.use(Wizard({
+  ...
+  '/confirm-submission': {
+    behaviours: ['complete'],
+    next: '/finished'
+  },
+  '/finished': {
+    allowPostComplete: true
+  }
+}, {}, {}));
+```
+

--- a/README.md
+++ b/README.md
@@ -124,8 +124,7 @@ Some behaviours are built-in to the Wizard, and can be declared by passing a str
 
 These are:
 
-* `complete` - if set to a step then this step will mark the application as complete. The user will then have their session reset if they attempt to access any step of the form. Steps which follow a complete-ing step should have their `allowPostComplete` option et to true.
-
+* `complete` - if applied to a step then this step will mark the application as complete. The user will then have their session reset if they attempt to access any step of the form. The `next` step of a completing step will always be accessible following completion. Any other steps which should also be accessible on a complete session should have their `allowPostComplete` option set to `true`.
 
 ```js
 //index.js
@@ -138,7 +137,8 @@ app.use(Wizard({
     behaviours: ['complete'],
     next: '/finished'
   },
-  '/finished': {
+  '/finished': {},
+  '/download-receipt': {
     allowPostComplete: true
   }
 }, {}, {}));

--- a/lib/behaviours/complete.js
+++ b/lib/behaviours/complete.js
@@ -4,6 +4,16 @@ const constants = require('../util/constants');
 
 module.exports = (superclass) => class extends superclass {
 
+  constructor(options) {
+    super(options);
+    if (options.next && options.steps && options.steps[options.next]) {
+      const nextOptions = options.steps[options.next];
+      if (typeof nextOptions.allowPostComplete === 'undefined') {
+        nextOptions.allowPostComplete = true;
+      }
+    }
+  }
+
   successHandler(req, res, callback) {
     req.sessionModel.set(constants.APPLICATION_COMPLETE, true);
     super.successHandler(req, res, callback);

--- a/lib/behaviours/complete.js
+++ b/lib/behaviours/complete.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const constants = require('../util/constants');
+
+module.exports = (superclass) => class extends superclass {
+
+  successHandler(req, res, callback) {
+    req.sessionModel.set(constants.APPLICATION_COMPLETE, true);
+    super.successHandler(req, res, callback);
+  }
+
+};

--- a/lib/behaviours/index.js
+++ b/lib/behaviours/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  complete: require('./complete')
+};

--- a/lib/middleware/check-complete.js
+++ b/lib/middleware/check-complete.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const constants = require('../util/constants');
+
+module.exports = (route, controller, steps, start) => {
+  return (req, res, next) => {
+    if (req.sessionModel.get(constants.APPLICATION_COMPLETE) && !controller.options.allowPostComplete) {
+      req.sessionModel.reset();
+      res.redirect(start);
+    }
+    next();
+  };
+};

--- a/lib/util/constants.js
+++ b/lib/util/constants.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  APPLICATION_COMPLETE: '__application_complete'
+};

--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -60,6 +60,7 @@ const Wizard = (steps, fields, settings) => {
     options.steps = steps;
     options.route = route;
     options.appConfig = settings.appConfig;
+    options.clearSession = options.clearSession || false;
 
     // default template is the same as the pathname
     options.template = options.template || route.replace(/^\//, '');

--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -8,7 +8,11 @@ const mix = require('mixwith').mix;
 
 let count = 0;
 
-const createController = (SuperClass, behaviours) => {
+const getController = (SuperClass, behaviours) => {
+  behaviours = behaviours ? _.castArray(behaviours) : [];
+  if (!behaviours.length) {
+    return SuperClass;
+  }
   /*
    * This class declaration could be better written using
    * array spread syntax, supported in node >= 5.11.0:
@@ -60,8 +64,6 @@ const Wizard = (steps, fields, settings) => {
 
     options.i18n = settings.i18n;
 
-    const SuperClass = options.controller || settings.controller;
-
     if (options.controller) {
       deprecate(
         'hof-form-wizard: Passing a custom step controller is deprecated',
@@ -69,11 +71,9 @@ const Wizard = (steps, fields, settings) => {
       );
     }
 
-    const behaviours = options.behaviours ? _.castArray(options.behaviours) : [];
-
-    const controller = new (behaviours.length ?
-      createController(SuperClass, behaviours) :
-      SuperClass)(options);
+    const SuperClass = options.controller || settings.controller;
+    const Controller = getController(SuperClass, options.behaviours);
+    const controller = new Controller(options);
 
     controller.use([
       require('./middleware/check-session')(route, controller, steps, first),

--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -6,6 +6,8 @@ const deprecate = require('deprecate');
 const FormController = require('hof-form-controller');
 const mix = require('mixwith').mix;
 
+const IncludedBehaviours = require('./behaviours');
+
 let count = 0;
 
 const getController = (SuperClass, behaviours) => {
@@ -13,6 +15,9 @@ const getController = (SuperClass, behaviours) => {
   if (!behaviours.length) {
     return SuperClass;
   }
+  behaviours = behaviours.map(behaviour => {
+    return typeof behaviour === 'string' ? IncludedBehaviours[behaviour] : behaviour;
+  });
   /*
    * This class declaration could be better written using
    * array spread syntax, supported in node >= 5.11.0:
@@ -77,6 +82,7 @@ const Wizard = (steps, fields, settings) => {
 
     controller.use([
       require('./middleware/check-session')(route, controller, steps, first),
+      require('./middleware/check-complete')(route, controller, steps, first),
       require('./middleware/check-progress')(route, controller, steps, first)
     ]);
     if (settings.csrf !== false) {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-config-homeoffice": "^2.0.0",
     "istanbul": "^0.4.3",
     "mocha": "^3.1.2",
+    "mocha-sandbox": "^1.0.0",
     "reqres": "^1.2.0",
     "sinon": "^1.17.6",
     "sinon-chai": "^2.8.0",

--- a/test/behaviours/complete.js
+++ b/test/behaviours/complete.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const BaseController = require('hof-form-controller');
+const mix = require('mixwith').mix;
+const Complete = require('../../lib/behaviours').complete;
+const APPLICATION_COMPLETE = require('../../lib/util/constants').APPLICATION_COMPLETE;
+const request = require('../helpers/request');
+const response = require('../helpers/response');
+const sandbox = require('mocha-sandbox');
+
+class Controller extends mix(BaseController).with(Complete) {}
+
+describe('Complete Behaviour', () => {
+
+  let req;
+  let res;
+  let controller;
+
+  beforeEach(() => {
+    req = request();
+    res = response();
+    controller = new Controller({});
+    sinon.stub(BaseController.prototype, 'successHandler').yieldsAsync();
+  });
+
+  afterEach(() => {
+    BaseController.prototype.successHandler.restore();
+  });
+
+  describe('successHandler', () => {
+
+    it('marks session model as complete', (done) => {
+      controller.successHandler(req, res, sandbox(() => {
+        req.sessionModel.get(APPLICATION_COMPLETE).should.equal(true);
+      }, done));
+    });
+
+    it('passes through to super method', (done) => {
+      controller.successHandler(req, res, sandbox(() => {
+        BaseController.prototype.successHandler.should.have.been.calledWith(req, res);
+      }, done));
+    });
+
+  });
+
+});

--- a/test/behaviours/complete.js
+++ b/test/behaviours/complete.js
@@ -19,15 +19,34 @@ describe('Complete Behaviour', () => {
   beforeEach(() => {
     req = request();
     res = response();
-    controller = new Controller({});
-    sinon.stub(BaseController.prototype, 'successHandler').yieldsAsync();
   });
 
-  afterEach(() => {
-    BaseController.prototype.successHandler.restore();
+  describe('constructor', () => {
+
+    it('sets the `allowPostComplete` option on the `next` step to true', () => {
+      const steps = {
+        '/one': {
+          next: '/two'
+        },
+        '/two': {
+        }
+      };
+      controller = new Controller({ steps, next: '/two' });
+      steps['/two'].allowPostComplete.should.equal(true);
+    });
+
   });
 
   describe('successHandler', () => {
+
+    beforeEach(() => {
+      controller = new Controller({});
+      sinon.stub(BaseController.prototype, 'successHandler').yieldsAsync();
+    });
+
+    afterEach(() => {
+      BaseController.prototype.successHandler.restore();
+    });
 
     it('marks session model as complete', (done) => {
       controller.successHandler(req, res, sandbox(() => {

--- a/test/middleware/spec.check-complete.js
+++ b/test/middleware/spec.check-complete.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const check = require('../../lib/middleware/check-complete');
+const APPLICATION_COMPLETE = require('../../lib/util/constants').APPLICATION_COMPLETE;
+const request = require('../helpers/request');
+const response = require('../helpers/response');
+
+describe('Check complete middleware', () => {
+  let req;
+  let res;
+  let middleware;
+
+  beforeEach(() => {
+    req = request();
+    res = response();
+    middleware = check('/', { options: {} }, {}, '/first');
+  });
+
+  it('redirects to the first step if the model is marked as complete', () => {
+    req.sessionModel.set(APPLICATION_COMPLETE, true);
+    middleware(req, res, () => {});
+    res.redirect.should.have.been.calledWith('/first');
+  });
+
+  it('passes through if the model is not marked as complete', () => {
+    const stub = sinon.stub();
+    req.sessionModel.unset(APPLICATION_COMPLETE);
+    middleware(req, res, stub);
+    res.redirect.should.not.have.been.called;
+    stub.should.have.been.calledWithExactly();
+  });
+
+  it('passes through if the controller has an `allowPostComplete` option set to true', () => {
+    const stub = sinon.stub();
+    middleware = check('/', { options: { allowPostComplete: true } }, {}, '/first');
+    req.sessionModel.unset(APPLICATION_COMPLETE);
+    middleware(req, res, stub);
+    res.redirect.should.not.have.been.called;
+    stub.should.have.been.calledWithExactly();
+  });
+
+});

--- a/test/spec.wizard.js
+++ b/test/spec.wizard.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Wizard = require('../lib/wizard');
+const Behaviours = require('../lib/behaviours');
 const StubController = require('./helpers/controller');
 const Behaviour = require('./helpers/behaviour');
 const request = require('./helpers/request');
@@ -135,6 +136,18 @@ describe('Form Wizard', () => {
         controller: obj.controller
       });
       obj.Behaviour.should.have.been.calledOnce.and.calledWithExactly(obj.controller);
+    });
+
+    it('maps predefined strings to behaviours', () => {
+      sinon.spy(Behaviours, 'complete');
+      Wizard({
+        '/': {
+          behaviours: 'complete'
+        }
+      }, {}, {
+        controller: obj.controller
+      });
+      Behaviours.complete.should.have.been.calledOnce.and.calledWithExactly(obj.controller);
     });
   });
 


### PR DESCRIPTION
Adds built-in behaviours to the wizard, which can be declared by passing a string instead of the mixin.

In particular, adds `complete` behaviour, which marks a session as complete, and prevents the user accessing any part of the app except those specifically marked as accessible.

This should replace the `start` controller from `hof-controllers`