### PR TITLE
Bugfix - handle '/' route if omitted

### DIFF
--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -48,6 +48,12 @@ const Wizard = (steps, fields, settings) => {
 
   let first;
 
+  if (Object.keys(steps).indexOf('/') === -1) {
+    app.get('/', (req, res) => {
+      res.redirect(first);
+    });
+  }
+
   _.each(steps, (options, route) => {
     first = first || route;
 

--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -48,7 +48,7 @@ const Wizard = (steps, fields, settings) => {
 
   let first;
 
-  if (Object.keys(steps).indexOf('/') === -1) {
+  if (!steps['/']) {
     app.get('/', (req, res) => {
       res.redirect(first);
     });

--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path = require('path');
 const express = require('express');
 const _ = require('lodash');
 const deprecate = require('deprecate');
@@ -50,7 +51,7 @@ const Wizard = (steps, fields, settings) => {
 
   if (!steps['/']) {
     app.get('/', (req, res) => {
-      res.redirect(first);
+      res.redirect(path.join(req.baseUrl, first));
     });
   }
 


### PR DESCRIPTION
Currently wizard doesn't handle '/' route if omitted from step config - a standard pattern is to redirect to the first step if '/' is hit and no step is defined. Added a check to see if '/' is present, if not then handle GET requests to '/' by redirecting to first step