### PR TITLE
Prevent looping steps invalidating themselves on edit

### DIFF
--- a/functional-tests/apps/loop-before-confirm.js
+++ b/functional-tests/apps/loop-before-confirm.js
@@ -1,0 +1,36 @@
+'use strict';
+
+module.exports = {
+  steps: {
+    '/one': {
+      next: '/two',
+      fields: ['field-1']
+    },
+    '/two': {
+      next: '/confirm',
+      forks: [
+        {
+          target: '/one',
+          condition: {
+            field: 'loop',
+            value: 'yes'
+          }
+        }
+      ],
+      continueOnEdit: true,
+      fields: ['loop']
+    },
+    '/confirm': {
+      behaviours: 'complete',
+      next: '/confirmation'
+    },
+    '/confirmation': {}
+  },
+  fields: {
+    loop: {
+      mixin: 'radio-group',
+      options: ['yes', 'no'],
+      validate: 'required'
+    }
+  }
+};

--- a/functional-tests/index.js
+++ b/functional-tests/index.js
@@ -73,4 +73,41 @@ describe('tests', () => {
       });
   });
 
+  it('does not autocomplete confirm page', () => {
+    return browser.goto('/confirm', { loop: 'no', fork: 'no' })
+      .getUrl()
+      .then((url) => {
+        assert.ok(url.includes('confirm'));
+      })
+      .url(`http://localhost:${port}/confirmation`)
+      .getUrl()
+      .then((url) => {
+        assert.ok(url.includes('/confirm'));
+      });
+  });
+
+  describe('with loop preceding confirm page', () => {
+
+    before(() => {
+      app = App(require('./apps/loop-before-confirm')).listen();
+      port = app.address().port;
+    });
+
+    after(() => {
+      app.close();
+    });
+
+    it('allows returning to the confirmation page from a loop page in an edit journey', () => {
+      return browser.goto('/confirm')
+        .url(`http://localhost:${port}/two/edit`)
+        .$('input[name="loop"][value="no"]').click()
+        .submitForm('form')
+        .getUrl()
+        .then((url) => {
+          assert.ok(url.includes('/confirm'));
+        });
+    });
+
+  });
+
 });

--- a/lib/middleware/check-progress.js
+++ b/lib/middleware/check-progress.js
@@ -37,6 +37,9 @@ module.exports = (route, controller, steps, start) => {
 
   // detect if a path will arrive back at the current step if followed
   const isLoop = (target, current) => {
+    debug('target', target);
+    debug('current', current);
+    debug('paths', getAllPossibleSteps(target, steps));
     return getAllPossibleSteps(target, steps).indexOf(current) > -1;
   };
 
@@ -47,8 +50,11 @@ module.exports = (route, controller, steps, start) => {
     const forks = controller.options.forks.map(fork => fork.target);
 
     let potentialPaths = [controller.options.next].concat(forks);
+    debug('potential paths', potentialPaths);
     // do not invalidate forks which loop back to the current step and are *not* being followed
-    potentialPaths = potentialPaths.filter(path => path === nextStep || !isLoop(path, req.path));
+    potentialPaths = potentialPaths.filter(path => path === nextStep || !isLoop(path, route));
+    debug('next', nextStep);
+    debug('potential paths', potentialPaths);
     // if we're following a loop then allow the loop to be invalidated
     const whitelist = isLoop(nextStep, req.path) ? [] : getAllPossibleSteps(nextStep, steps);
     // aggregate all potential journeys from the invalidating step

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "debug": "^2.1.2",
     "deprecate": "^1.0.0",
     "express": "^4.12.2",
-    "hof-form-controller": "^3.0.1",
+    "hof-form-controller": "^4.0.0",
     "hof-model": "^2.0.0",
     "hogan.js": "^3.0.2",
     "i18n-lookup": "^0.1.0",


### PR DESCRIPTION
The test for a loop was using `req.path` to filter loops, but on an edit journey `req.path` is suffixed with `/edit` and so does not match its own base path.

Use the step's `route` instead of `req.path` which is never appended and so can be used to match reliably.