### PR TITLE
feature - expose field config to controller

### DIFF
--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -68,6 +68,7 @@ const Wizard = (steps, fields, settings) => {
     options.route = route;
     options.appConfig = settings.appConfig;
     options.clearSession = options.clearSession || false;
+    options.fieldsConfig = _.cloneDeep(fields);
 
     // default template is the same as the pathname
     options.template = options.template || route.replace(/^\//, '');


### PR DESCRIPTION
A controller has access to the config for its 'own' fields, and other field configs that have been specifically assigned to other steps through this.options.steps.{step-name}.fields. However there is no access to the root fieldConfig provided on wizard init meaning a step needs to know which fields it needs to include when wizard is initialised