### PR TITLE
Allow specifying formatters on wizard settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ A number of options can be passed to the wizard as a third argument to customise
 `templatePath` - provides the location within `app.get('views')` that templates are stored. Default `pages`.
 * `controller` - The constructor for the controller to be used for request handling. The default is an extension of the [hof-form-controller](https://www.npmjs.com/package/hof-form-controller), which is exported as a `Controller` property of this module. If custom behaviour is required for a particular form step then custom extensions can be defined by passing a list of Behaviours - see [Behaviours](#behaviours)
 `params` - define a suffix for the routes for supporting additional URL parameters.
+`formatters` - defines a standard list of formatters to be applied to all field data. Default: `['trim', 'singlespaces', 'hyphens']` - see [formatters.js](https://github.com/UKHomeOfficeForms/hof-form-controller/blob/master/lib/formatting/formatters.js) for a list of available formatters.
 
 ### Behaviours
 

--- a/functional-tests/apps/looping-step-before-loop.js
+++ b/functional-tests/apps/looping-step-before-loop.js
@@ -1,0 +1,37 @@
+'use strict';
+
+module.exports = {
+  steps: {
+    '/loop': {
+      next: '/confirm',
+      forks: [
+        {
+          target: '/two',
+          condition: {
+            field: 'loop',
+            value: 'yes'
+          }
+        }
+      ],
+      continueOnEdit: true,
+      fields: ['loop']
+    },
+    '/two': {
+      next: '/loop',
+      continueOnEdit: true,
+      fields: ['field-1']
+    },
+    '/confirm': {
+      behaviours: 'complete',
+      next: '/confirmation'
+    },
+    '/confirmation': {}
+  },
+  fields: {
+    loop: {
+      mixin: 'radio-group',
+      options: ['yes', 'no'],
+      validate: 'required'
+    }
+  }
+};

--- a/functional-tests/index.js
+++ b/functional-tests/index.js
@@ -110,7 +110,7 @@ describe('tests', () => {
 
   });
 
-  describe('with looping step beore and after the loop', () => {
+  describe('with looping step before and after the loop', () => {
 
     before(() => {
       app = App(require('./apps/looping-step-before-loop')).listen();

--- a/functional-tests/index.js
+++ b/functional-tests/index.js
@@ -110,4 +110,28 @@ describe('tests', () => {
 
   });
 
+  describe('with looping step beore and after the loop', () => {
+
+    before(() => {
+      app = App(require('./apps/looping-step-before-loop')).listen();
+      port = app.address().port;
+    });
+
+    after(() => {
+      app.close();
+    });
+
+    it.only('allows accessing the loop through first looping step', () => {
+      return browser.url(`http://localhost:${port}/loop`)
+        .$('input[name="loop"][value="yes"]').click()
+        .submitForm('form')
+        .getUrl()
+        .then((url) => {
+          console.log(url);
+          assert.ok(url.includes('/two'));
+        });
+    });
+
+  });
+
 });

--- a/lib/middleware/check-progress.js
+++ b/lib/middleware/check-progress.js
@@ -56,7 +56,7 @@ module.exports = (route, controller, steps, start) => {
     debug('next', nextStep);
     debug('potential paths', potentialPaths);
     // if we're following a loop then allow the loop to be invalidated
-    const whitelist = isLoop(nextStep, req.path) ? [] : getAllPossibleSteps(nextStep, steps);
+    const whitelist = isLoop(nextStep, req.path) ? [route] : getAllPossibleSteps(nextStep, steps);
     // aggregate all potential journeys from the invalidating step
     const invalidateSteps = potentialPaths.reduce((arr, step) => {
       return arr.concat(getAllPossibleSteps(step, steps));

--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -42,6 +42,7 @@ const Wizard = (steps, fields, settings) => {
   }
 
   settings.name = `hof-wizard-${settings.name}`;
+  settings.formatters = settings.formatters || [];
 
   const app = express.Router();
 
@@ -69,6 +70,8 @@ const Wizard = (steps, fields, settings) => {
     options.appConfig = settings.appConfig;
     options.clearSession = options.clearSession || false;
     options.fieldsConfig = _.cloneDeep(fields);
+
+    options.defaultFormatters = [].concat(settings.formatters);
 
     // default template is the same as the pathname
     options.template = options.template || route.replace(/^\//, '');

--- a/test/spec.wizard.js
+++ b/test/spec.wizard.js
@@ -28,7 +28,8 @@ describe('Form Wizard', () => {
         }
       }, {}, {
         templatePath: '/a/path',
-        controller: obj.controller
+        controller: obj.controller,
+        formatters: 'escape'
       });
     });
 
@@ -45,6 +46,27 @@ describe('Form Wizard', () => {
     it('passes the route to the controller', () => {
       obj.controller.should.have.been.calledWithMatch({
         route: '/'
+      });
+    });
+
+    it('passes default formatters to the controller', () => {
+      obj.controller.should.have.been.calledWithMatch({
+        defaultFormatters: ['escape']
+      });
+    });
+
+    it('passes an array of default formatters to the controller', () => {
+      wizard = Wizard({
+        '/': {
+          template: 'template',
+        }
+      }, {}, {
+        templatePath: '/a/path',
+        controller: obj.controller,
+        formatters: ['escape', 'trim']
+      });
+      obj.controller.should.have.been.calledWithMatch({
+        defaultFormatters: ['escape', 'trim']
       });
     });
 


### PR DESCRIPTION
This allows a user to specify a default set of formatters for all steps in a wizard, rather than having to specify per-step as is currently required.

Based on a conversation in the hof slack channel about global formatters.