### PR TITLE
Do not reset steps tracker when submitting the first step

### DIFF
--- a/functional-tests/index.js
+++ b/functional-tests/index.js
@@ -73,6 +73,20 @@ describe('tests', () => {
       });
   });
 
+  it('can go back to confirm page after editing first step', () => {
+    return browser.goto('/confirm', { loop: 'no', fork: 'no' })
+      .getUrl()
+      .then((url) => {
+        assert.ok(url.includes('confirm'));
+      })
+      .url(`http://localhost:${port}/one/edit`)
+      .submitForm('form')
+      .getUrl()
+      .then((url) => {
+        assert.ok(url.includes('/confirm'));
+      });
+  });
+
   it('does not autocomplete confirm page', () => {
     return browser.goto('/confirm', { loop: 'no', fork: 'no' })
       .getUrl()

--- a/lib/middleware/check-progress.js
+++ b/lib/middleware/check-progress.js
@@ -75,9 +75,6 @@ module.exports = (route, controller, steps, start) => {
     if (index > -1) {
       sessionsteps.splice(index, 1);
     }
-    if (path === start) {
-      sessionsteps = [];
-    }
     sessionsteps.push(path);
     req.sessionModel.set('steps', sessionsteps);
 


### PR DESCRIPTION
This behaviour shouldn't be default as there's no reason to always reset the session steps when submitting the first step, and in most applications this would not be desirable.

If it is required then it should be done in implementations as custom behaviour.