### PR TITLE
Fix tests broken in previous PR

### DIFF
--- a/functional-tests/apps/default.js
+++ b/functional-tests/apps/default.js
@@ -2,7 +2,14 @@
 
 module.exports = {
   steps: {
+    '/zero': {
+      next: '/one'
+    },
     '/one': {
+      next: '/one-a',
+      fields: ['field-1']
+    },
+    '/one-a': {
       next: '/two',
       fields: ['field-1']
     },

--- a/functional-tests/index.js
+++ b/functional-tests/index.js
@@ -45,9 +45,10 @@ describe('tests', () => {
     return browser.goto('/two')
       .$('input[name="loop"][value="yes"]').click()
       .submitForm('form')
+      .submitForm('form')
       .getUrl()
       .then((url) => {
-        assert.ok(url.includes('/one'));
+        assert.ok(url.includes('/one-a'));
       })
       .url(`http://localhost:${port}/two`)
       .getUrl()
@@ -135,13 +136,12 @@ describe('tests', () => {
       app.close();
     });
 
-    it.only('allows accessing the loop through first looping step', () => {
+    it('allows accessing the loop through first looping step', () => {
       return browser.url(`http://localhost:${port}/loop`)
         .$('input[name="loop"][value="yes"]').click()
         .submitForm('form')
         .getUrl()
         .then((url) => {
-          console.log(url);
           assert.ok(url.includes('/two'));
         });
     });


### PR DESCRIPTION
One of the functional tests had been broken by a previous PR, that had accidentally included an `it.only`.

Remove the `only` and fix the broken test.

Fix is that a loop should only be considered to be "started" when a step has actually been submitted. Going to a page an dnot submitting it should allow return. Add an extra step into the loop and submit the first step of the loop to test this case.