### PR TITLE
Configurable confirm step

### DIFF
--- a/functional-tests/apps/custom-confirm-step.js
+++ b/functional-tests/apps/custom-confirm-step.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  options: {
+    confirmStep: '/summary'
+  },
+  steps: {
+    '/one': {
+      next: '/two',
+      fields: ['field-1']
+    },
+    '/two': {
+      next: '/three',
+      fields: ['field-2']
+    },
+    '/three': {
+      next: '/summary',
+      fields: ['field-3']
+    },
+    '/summary': {
+      behaviours: 'complete',
+      next: '/confirmation'
+    },
+    '/confirmation': {}
+  },
+  fields: {}
+};

--- a/functional-tests/apps/default.js
+++ b/functional-tests/apps/default.js
@@ -2,7 +2,14 @@
 
 module.exports = {
   steps: {
+    '/zero': {
+      next: '/one'
+    },
     '/one': {
+      next: '/one-a',
+      fields: ['field-1']
+    },
+    '/one-a': {
       next: '/two',
       fields: ['field-1']
     },

--- a/functional-tests/index.js
+++ b/functional-tests/index.js
@@ -45,9 +45,10 @@ describe('tests', () => {
     return browser.goto('/two')
       .$('input[name="loop"][value="yes"]').click()
       .submitForm('form')
+      .submitForm('form')
       .getUrl()
       .then((url) => {
-        assert.ok(url.includes('/one'));
+        assert.ok(url.includes('/one-a'));
       })
       .url(`http://localhost:${port}/two`)
       .getUrl()
@@ -135,13 +136,12 @@ describe('tests', () => {
       app.close();
     });
 
-    it.only('allows accessing the loop through first looping step', () => {
+    it('allows accessing the loop through first looping step', () => {
       return browser.url(`http://localhost:${port}/loop`)
         .$('input[name="loop"][value="yes"]').click()
         .submitForm('form')
         .getUrl()
         .then((url) => {
-          console.log(url);
           assert.ok(url.includes('/two'));
         });
     });

--- a/functional-tests/index.js
+++ b/functional-tests/index.js
@@ -148,4 +148,27 @@ describe('tests', () => {
 
   });
 
+  describe('configurable confirm step url', () => {
+
+    before(() => {
+      app = App(require('./apps/custom-confirm-step')).listen();
+      port = app.address().port;
+    });
+
+    after(() => {
+      app.close();
+    });
+
+    it('allows accessing the loop through first looping step', () => {
+      return browser.goto('/summary')
+        .url(`http://localhost:${port}/two/edit`)
+        .submitForm('form')
+        .getUrl()
+        .then((url) => {
+          assert.ok(url.includes('/summary'));
+        });
+    });
+
+  });
+
 });

--- a/functional-tests/lib/app.js
+++ b/functional-tests/lib/app.js
@@ -26,6 +26,6 @@ module.exports = (config) => {
   app.use(session({ secret: 'not a secret', resave: true, saveUninitialized: false }));
   app.use(partials(app));
   app.use(mixins());
-  app.use(Wizard(config.steps, config.fields));
+  app.use(Wizard(config.steps, config.fields, config.options));
   return app;
 };

--- a/lib/wizard.js
+++ b/lib/wizard.js
@@ -68,6 +68,7 @@ const Wizard = (steps, fields, settings) => {
     options.steps = steps;
     options.route = route;
     options.appConfig = settings.appConfig;
+    options.confirmStep = settings.confirmStep;
     options.clearSession = options.clearSession || false;
     options.fieldsConfig = _.cloneDeep(fields);
 

--- a/test/spec.wizard.js
+++ b/test/spec.wizard.js
@@ -27,6 +27,7 @@ describe('Form Wizard', () => {
           template: 'template',
         }
       }, {}, {
+        confirmStep: '/summary',
         templatePath: '/a/path',
         controller: obj.controller,
         formatters: 'escape'
@@ -46,6 +47,12 @@ describe('Form Wizard', () => {
     it('passes the route to the controller', () => {
       obj.controller.should.have.been.calledWithMatch({
         route: '/'
+      });
+    });
+
+    it('passes the confirm step to the controller', () => {
+      obj.controller.should.have.been.calledWithMatch({
+        confirmStep: '/summary'
       });
     });
 


### PR DESCRIPTION
Previously the confirm step was configurable, but only by setting the custom url on every step, which is obviously not really workable.

Instead allow a single point of configuration to set the url of the confirm/summary page.

Branches off the top of #25 to ensure full tests run